### PR TITLE
Optimized long[] serialization

### DIFF
--- a/library/src/main/java/com/dslplatform/json/JsonWriter.java
+++ b/library/src/main/java/com/dslplatform/json/JsonWriter.java
@@ -11,6 +11,14 @@ public final class JsonWriter extends Writer {
 	private static final Charset UTF_8 = Charset.forName("UTF-8");
 
 	public final byte[] tmp = new byte[48];
+
+	final byte[] ensureCapacity(final int free) {
+		if (position + free >= result.length) {
+			result = Arrays.copyOf(result, result.length + (result.length << 1) + free);
+		}
+		return result;
+	}
+
 	private int position;
 	private byte[] result;
 
@@ -259,6 +267,12 @@ public final class JsonWriter extends Writer {
 			_result[p++] = tmp[i];
 		}
 		position = p;
+	}
+
+	final void copyFromOffset(int offset) {
+		final int size = result.length - offset;
+		System.arraycopy(result, offset, result, position, size);
+		position += size;
 	}
 
 	public final void writeBuffer(final int len) {

--- a/library/src/main/java/com/dslplatform/json/NumberConverter.java
+++ b/library/src/main/java/com/dslplatform/json/NumberConverter.java
@@ -638,19 +638,78 @@ public abstract class NumberConverter {
 		}
 	}
 
-	public static void serialize(final long[] value, final JsonWriter sw) {
-		if (value == null) {
+	public static void serialize(final long[] values, final JsonWriter sw) {
+		if (values == null) {
 			sw.writeNull();
-		} else if (value.length == 0) {
+		} else if (values.length == 0) {
 			sw.writeAscii("[]");
 		} else {
-			sw.writeByte(JsonWriter.ARRAY_START);
-			serialize(value[0], sw);
-			for(int i = 1; i < value.length; i++) {
-				sw.writeByte(JsonWriter.COMMA);
-				serialize(value[i], sw);
+			final int maxNeeded = values.length * 21;
+			final byte[] buf = sw.ensureCapacity(maxNeeded);
+
+			int charPos = buf.length - 1;
+			buf[charPos] = ']';
+
+			for (int index = values.length - 1; index >= 0; index--) {
+				charPos--;
+
+				long value = values[index];
+				if (value == Long.MIN_VALUE) {
+					buf[charPos     ] = '8';
+					buf[charPos -  1] = '0';
+					buf[charPos -  2] = '8';
+					buf[charPos -  3] = '5';
+					buf[charPos -  4] = '7';
+					buf[charPos -  5] = '7';
+					buf[charPos -  6] = '4';
+					buf[charPos -  7] = '5';
+					buf[charPos -  8] = '8';
+					buf[charPos -  9] = '6';
+					buf[charPos - 10] = '3';
+					buf[charPos - 11] = '0';
+					buf[charPos - 12] = '2';
+					buf[charPos - 13] = '7';
+					buf[charPos - 14] = '3';
+					buf[charPos - 15] = '3';
+					buf[charPos - 16] = '2';
+					buf[charPos - 17] = '2';
+					buf[charPos - 18] = '9';
+					buf[charPos - 19] = '-';
+					buf[charPos - 20] = ',';
+					charPos -= 20;
+				} else {
+					long q;
+					int r;
+					long i;
+					final int wasMinus;
+					if (value < 0) {
+						i = -value;
+						wasMinus = 1;
+					} else {
+						i = value;
+						wasMinus = 0;
+					}
+
+					int v = 0;
+					do {
+						q = i / 100;
+						r = (int) (i - ((q << 6) + (q << 5) + (q << 2)));
+						i = q;
+						v = Digits[r];
+						buf[charPos--] = (byte) v;
+						buf[charPos--] = (byte) (v >> 8);
+					} while (i != 0);
+
+					r = charPos + (v >> 16);
+					buf[r] = MINUS;
+
+					charPos = r - wasMinus;
+					buf[charPos] = JsonWriter.COMMA;
+				}
 			}
-			sw.writeByte(JsonWriter.ARRAY_END);
+
+			buf[charPos] = '[';
+			sw.copyFromOffset(charPos);
 		}
 	}
 

--- a/library/src/main/java/com/dslplatform/json/NumberConverter.java
+++ b/library/src/main/java/com/dslplatform/json/NumberConverter.java
@@ -680,30 +680,25 @@ public abstract class NumberConverter {
 				} else {
 					long q;
 					int r;
-					long i;
-					final int wasMinus;
-					if (value < 0) {
-						i = -value;
-						wasMinus = 1;
-					} else {
-						i = value;
-						wasMinus = 0;
-					}
+					final long sign = value >> 63;
+					long i = (value + sign) ^ sign;
 
-					int v = 0;
+					int v;
 					do {
-						q = i / 100;
-						r = (int) (i - ((q << 6) + (q << 5) + (q << 2)));
+						q = i / 1000;
+						r = (int) (i - q * 1000);
 						i = q;
-						v = Digits[r];
+						v = DIGITS[r];
 						buf[charPos--] = (byte) v;
 						buf[charPos--] = (byte) (v >> 8);
-					} while (i != 0);
+						buf[charPos--] = (byte) (v >> 16);
+					}
+					while (i != 0);
 
-					r = charPos + (v >> 16);
+					r = charPos + (v >> 24);
 					buf[r] = MINUS;
 
-					charPos = r - wasMinus;
+					charPos = r + (int) sign;
 					buf[charPos] = JsonWriter.COMMA;
 				}
 			}

--- a/library/src/test/java/com.dslplatform.json/NumberConverterTest.java
+++ b/library/src/test/java/com.dslplatform.json/NumberConverterTest.java
@@ -32,6 +32,49 @@ public class NumberConverterTest {
 		}
 	}
 
+	@Test
+	public void testCollectionSerialization() throws IOException {
+		final Random rnd = new Random(1337);
+		final List<Long> collection = new ArrayList<Long>();
+		for (long i = 1L; i <= 1000000000000000000L; i *= 10) {
+			collection.add(i);                                    //  1000000
+			collection.add(-i);                                   // -1000000
+			for (int r = 0; r < 100; r++) {
+				collection.add(Math.abs(rnd.nextLong()) % i);     //   234992
+				collection.add(- (Math.abs(rnd.nextLong()) % i)); //  -712919
+			}
+		}
+		collection.add(Long.MIN_VALUE);
+		collection.add(Long.MAX_VALUE);
+
+		final Long[] boxes = collection.toArray(new Long[0]);
+		final long[] primitives = new long[boxes.length];
+		for (int i = 0; i < primitives.length; i++) {
+			primitives[i] = boxes[i];
+		}
+
+		final String expected; {
+			final StringBuilder tmp = new StringBuilder("[");
+			for (long value : primitives) {
+				tmp.append(value).append(',');
+			}
+			tmp.setLength(tmp.length() - 1);
+			tmp.append(']');
+			expected = tmp.toString();
+		}
+
+		final JsonWriter sw = new JsonWriter();
+		NumberConverter.serialize(primitives, sw);
+		Assert.assertEquals(expected, sw.toString());
+
+		sw.reset();
+		sw.serialize(collection, NumberConverter.LongWriter);
+		Assert.assertEquals(expected, sw.toString());
+
+		sw.reset();
+		sw.serialize(boxes, NumberConverter.LongWriter);
+		Assert.assertEquals(expected, sw.toString());
+	}
 
 	@Test
 	public void testPowersOf10() throws IOException {

--- a/library/src/test/java/com.dslplatform.json/NumberConverterTest.java
+++ b/library/src/test/java/com.dslplatform.json/NumberConverterTest.java
@@ -5,7 +5,10 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 public class NumberConverterTest {
 	@Test


### PR DESCRIPTION
This is a proof-of-concept for an optimized way to perform integer collection serialization.
Instead of using a tmp byte[], we ensure that the result byte[] is large enough and write to its end directly.

We are writing tokens and the MINUS sign directly to the result buffer, as there is no need to check for size once we allocate 21 bytes for each long.

In order for this approach to work, we must be able to traverse the collection backwards,
as we are writing to the end of the result buffer in reverse order.
After we are finished writing, we shift the contents from the end of the buffer to where it's supposed to be.

This approach yields a speedup of ~20% compared to one-by-one vanilla serialization.