### PR TITLE
Remove explicitly referenced META-INF in resources

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -88,12 +88,6 @@
 	</properties>
 
     <build>
-        <resources>
-            <resource>
-                <directory>META-INF</directory>
-                <targetPath>META-INF</targetPath>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The service registration was not being copied to the target jar.