### PR TITLE
Fix JsonReader#getLastName off by one error.

### DIFF
--- a/library/src/main/java/com/dslplatform/json/JsonReader.java
+++ b/library/src/main/java/com/dslplatform/json/JsonReader.java
@@ -413,25 +413,13 @@ public class JsonReader<TContext> {
 	}
 
 	public final int fillName() throws IOException {
-		if (last != '"') {
-			throw new IOException("Expecting '\"' at position " + positionInStream() + ". Found " + (char) last);
-		}
-		tokenStart = currentIndex;
-		int ci = currentIndex;
-		long hash = 0x811c9dc5;
-		while (ci < buffer.length) {
-			final byte b = buffer[ci++];
-			if (b == '"') break;
-			hash ^= b;
-			hash *= 0x1000193;
-		}
-		nameEnd = currentIndex = ci;
+		final int hash = calcHash();
 		if (read() != ':') {
 			if (!wasWhiteSpace() || getNextToken() != ':') {
 				throw new IOException("Expecting ':' at position " + positionInStream() + ". Found " + (char) last);
 			}
 		}
-		return (int) hash;
+		return hash;
 	}
 
 	public final int calcHash() throws IOException {
@@ -447,7 +435,7 @@ public class JsonReader<TContext> {
 			hash ^= b;
 			hash *= 0x1000193;
 		}
-		currentIndex = ci;
+		nameEnd = currentIndex = ci;
 		return (int) hash;
 	}
 

--- a/library/src/main/java/com/dslplatform/json/JsonReader.java
+++ b/library/src/main/java/com/dslplatform/json/JsonReader.java
@@ -464,7 +464,7 @@ public class JsonReader<TContext> {
 	}
 
 	public final String getLastName() throws IOException {
-		return new String(buffer, tokenStart, currentIndex - tokenStart - 1, "ISO-8859-1");
+		return new String(buffer, tokenStart, nameEnd - tokenStart - 1, "ISO-8859-1");
 	}
 
 	private byte skipString() throws IOException {

--- a/library/src/test/java/com/dslplatform/json/ReaderTest.java
+++ b/library/src/test/java/com/dslplatform/json/ReaderTest.java
@@ -1,14 +1,9 @@
 package com.dslplatform.json;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
 
 public class ReaderTest {
 
@@ -18,6 +13,7 @@ public class ReaderTest {
 		final JsonReader<Object> jr = new JsonReader<Object>(buf, null);
 		jr.getNextToken();
 		jr.fillName();
+		Assert.assertEquals("number", jr.getLastName());
 		jr.getNextToken();
 		Assert.assertTrue(jr.wasLastName("number"));
 		int num = NumberConverter.deserializeInt(jr);

--- a/library/src/test/java/com/dslplatform/json/ReaderTest.java
+++ b/library/src/test/java/com/dslplatform/json/ReaderTest.java
@@ -19,4 +19,14 @@ public class ReaderTest {
 		int num = NumberConverter.deserializeInt(jr);
 		Assert.assertEquals(1234, num);
 	}
+
+	@Test
+	public void testCalcHashNameEndSameAsFillName() throws IOException {
+		final byte[] buf = "\"number\":1234".getBytes("UTF-8");
+		final JsonReader<Object> jr = new JsonReader<Object>(buf, null);
+		jr.getNextToken();
+		jr.calcHash();
+		Assert.assertTrue(jr.wasLastName("number"));
+		Assert.assertEquals("number", jr.getLastName());
+	}
 }


### PR DESCRIPTION
Usage of `currentIndex` is causing `getLastName` to be one character too long, causing it to include the closing '"' character.  I noticed `wasLastName` is using `nameEnd`, so I changed it to match.