### PR TITLE
Serialize UUID by providing hi and lo long values

### DIFF
--- a/library/src/main/java/com/dslplatform/json/UUIDConverter.java
+++ b/library/src/main/java/com/dslplatform/json/UUIDConverter.java
@@ -53,8 +53,10 @@ public abstract class UUIDConverter {
 	}
 
 	public static void serialize(final UUID value, final JsonWriter sw) {
-		final long hi = value.getMostSignificantBits();
-		final long lo = value.getLeastSignificantBits();
+		serialize(value.getMostSignificantBits(), value.getLeastSignificantBits(), sw);
+	}
+
+	public static void serialize(final long hi, final long lo, final JsonWriter sw) {
 		final int hi1 = (int) (hi >> 32);
 		final int hi2 = (int) hi;
 		final int lo1 = (int) (lo >> 32);


### PR DESCRIPTION
This allows to serialize an UUID without having to create an actual
java.util.UUID instance to do so, which would create garbage.

I don't suspect performance regressions because of the additional
method call to the overloaded serialize method as the JIT should be
able to inline it.