### PR TITLE
Fix loading converters within annotation processor

### DIFF
--- a/java8/src/main/java/com/dslplatform/json/processor/CompiledJsonAnnotationProcessor.java
+++ b/java8/src/main/java/com/dslplatform/json/processor/CompiledJsonAnnotationProcessor.java
@@ -149,7 +149,8 @@ public class CompiledJsonAnnotationProcessor extends AbstractProcessor {
 		if (roundEnv.processingOver()) {
 			return false;
 		}
-		final DslJson<Object> dslJson = new DslJson<>(Settings.withRuntime().includeServiceLoader());
+		final ServiceLoader<Configuration> serviceLoader = ServiceLoader.load(Configuration.class, getClass().getClassLoader());
+		final DslJson<Object> dslJson = new DslJson<>(Settings.withRuntime().includeServiceLoader(serviceLoader));
 		Set<Type> knownEncoders = dslJson.getRegisteredEncoders();
 		Set<Type> knownDecoders = dslJson.getRegisteredDecoders();
 		Set<String> allTypes = new HashSet<>();

--- a/library/src/main/java/com/dslplatform/json/DslJson.java
+++ b/library/src/main/java/com/dslplatform/json/DslJson.java
@@ -272,17 +272,27 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 
 		/**
 		 * Load converters using `ServiceLoader.load(Configuration.class)`
+		 * 
+		 * @see #includeServiceLoader(ServiceLoader) 
+		 */
+		public Settings<TContext> includeServiceLoader() {
+			return includeServiceLoader(ServiceLoader.load(Configuration.class));
+		}
+		
+		/**
+		 * Load converters using provided `ServiceLoader` instance
 		 * Will scan through `META-INF/services/com.dslplatform.json.Configuration` file and register implementation during startup.
 		 * This will pick up compile time databindings if they are available in specific folder.
 		 * <p>
 		 * Note that gradle on Android has issues with preserving that file, in which case it can be provided manually.
 		 * DslJson will fall back to "expected" class name if it doesn't find anything during scanning.
 		 *
+		 * @param serviceLoader converters service loader
 		 * @return itself
 		 */
-		public Settings<TContext> includeServiceLoader() {
+		public Settings<TContext> includeServiceLoader(ServiceLoader<Configuration> serviceLoader) {
 			withServiceLoader = true;
-			for (Configuration c : ServiceLoader.load(Configuration.class, getClass().getClassLoader())) {
+			for (Configuration c : serviceLoader) {
 				boolean hasConfiguration = false;
 				Class<?> manifest = c.getClass();
 				for (Configuration cur : configurations) {

--- a/library/src/main/java/com/dslplatform/json/DslJson.java
+++ b/library/src/main/java/com/dslplatform/json/DslJson.java
@@ -282,7 +282,7 @@ public class DslJson<TContext> implements UnknownSerializer, TypeLookup {
 		 */
 		public Settings<TContext> includeServiceLoader() {
 			withServiceLoader = true;
-			for (Configuration c : ServiceLoader.load(Configuration.class)) {
+			for (Configuration c : ServiceLoader.load(Configuration.class, getClass().getClassLoader())) {
 				boolean hasConfiguration = false;
 				Class<?> manifest = c.getClass();
 				for (Configuration cur : configurations) {


### PR DESCRIPTION
Annotation processor fails to load converters defined in "META-INF/services/com.dslplatform.json.Configuration" from third-party libraries.

The problem is ServiceLoader uses Thread.currentThread().getContextClassLoader() when a ClassLoader is not specified which cannot see the META-INF\services files from within an Annotation Processor but can from the main method.
[https://stackoverflow.com/a/45103971](https://stackoverflow.com/a/45103971)