### PR TITLE
Add support for generic types to Java8 annotation processor

### DIFF
--- a/library/src/main/java/com/dslplatform/json/processor/Analysis.java
+++ b/library/src/main/java/com/dslplatform/json/processor/Analysis.java
@@ -171,9 +171,9 @@ public class Analysis {
 				for (Map.Entry<String, TypeMirror> kv : info.unknowns.entrySet()) {
 					AttributeInfo attr = info.attributes.get(kv.getKey());
 					if (attr != null && (attr.converter != null || attr.isJsonObject)) continue;
-					Map<String, Boolean> references = analyzeParts(kv.getValue());
-					for (Map.Entry<String, Boolean> pair : references.entrySet()) {
-						if (!pair.getValue()) {
+					Map<String, PartKind> references = analyzeParts(kv.getValue());
+					for (Map.Entry<String, PartKind> pair : references.entrySet()) {
+						if (pair.getValue() == PartKind.UNKNOWN) {
 							hasError = hasError || unknownTypes == UnknownTypes.ERROR;
 							Diagnostic.Kind kind = unknownTypes == UnknownTypes.ERROR ? Diagnostic.Kind.ERROR : Diagnostic.Kind.WARNING;
 							if (kind == Diagnostic.Kind.ERROR || logLevel.isVisible(LogLevel.INFO)) {
@@ -200,7 +200,7 @@ public class Analysis {
 			if (unknownTypes != UnknownTypes.ALLOW) {
 				for (AttributeInfo attr : info.attributes.values()) {
 					if (attr.converter != null || attr.isJsonObject) continue;
-					Map<String, Boolean> references = analyzeParts(attr.type);
+					Map<String, PartKind> references = analyzeParts(attr.type);
 					for (String r : references.keySet()) {
 						StructInfo target = structs.get(r);
 						if (target != null && target.type == ObjectType.MIXIN && target.implementations.size() == 0) {
@@ -589,14 +589,26 @@ public class Analysis {
 			boolean isJsonObject = isJsonObject(referenceElement);
 			boolean typeResolved = converter != null || isJsonObject || supportedTypes.contains(referenceName) || structs.containsKey(referenceName);
 			boolean hasUnknown = false;
-			if (!typeResolved) {
-				Map<String, Boolean> references = analyzeParts(referenceType);
-				for (Map.Entry<String, Boolean> kv : references.entrySet()) {
-					if (!kv.getValue()) {
+			boolean hasOwnerStructType = false;
+			Map<String, Integer> typeVariablesIndex = new HashMap<String, Integer>();
+			if (!typeResolved || info.isParameterized) {
+				Map<String, PartKind> references = analyzeParts(referenceType);
+				for (Map.Entry<String, PartKind> kv : references.entrySet()) {
+					String partTypeName = kv.getKey();
+					PartKind partKind = kv.getValue();
+
+					if (partKind == PartKind.UNKNOWN) {
 						hasUnknown = true;
+					}
+					if (partKind == PartKind.TYPE_VARIABLE) {
+						typeVariablesIndex.put(partTypeName, info.typeParametersNames.indexOf(partTypeName));
+					}
+					if (partTypeName.equals(info.element.toString())) {
+						hasOwnerStructType = true;
 					}
 				}
 			}
+
 			AnnotationMirror annotation = access.annotation;
 			CompiledJson.TypeSignature typeSignature = typeSignatureValue(annotation);
 			AttributeInfo attr =
@@ -614,7 +626,9 @@ public class Analysis {
 							isFullMatch(element, annotation),
 							typeSignature,
 							converter,
-							isJsonObject);
+							isJsonObject,
+							typeVariablesIndex,
+							hasOwnerStructType);
 			String[] alternativeNames = getAlternativeNames(attr.element);
 			if (alternativeNames != null) {
 				attr.alternativeNames.addAll(Arrays.asList(alternativeNames));
@@ -697,7 +711,7 @@ public class Analysis {
 
 	private void findStructs(Element el, DeclaredType discoveredBy, String errorMessge, Stack<String> path) {
 		if (!(el instanceof TypeElement)) return;
-		String typeName = el.asType().toString();
+		String typeName = el.toString();
 		if (structs.containsKey(typeName) || supportedTypes.contains(typeName)) return;
 		final TypeElement element = (TypeElement) el;
 		boolean isMixin = element.getKind() == ElementKind.INTERFACE
@@ -951,51 +965,56 @@ public class Analysis {
 		return null;
 	}
 
-	private Map<String, Boolean> analyzeParts(TypeMirror target) {
-		String typeName = target.toString();
-		if (structs.containsKey(typeName)) {
-			return Collections.singletonMap(typeName, true);
-		} else if (supportedTypes.contains(typeName)) {
-			return Collections.singletonMap(typeName, true);
-		}
-		if (target instanceof ArrayType) {
-			ArrayType at = (ArrayType) target;
-			return analyzeParts(at.getComponentType());
-		}
-		int genInd = typeName.indexOf('<');
-		if (genInd == -1) return Collections.singletonMap(typeName, false);
-		Map<String, Boolean> found = new LinkedHashMap<String, Boolean>();
-		String rawClass = typeName.substring(0, genInd);
-		TypeElement raw = elements.getTypeElement(rawClass);
-		if (raw != null) {
-			if (supportedTypes.contains(rawClass)) {
-				found.put(rawClass, true);
-			} else {
-				found.put(rawClass, containerSupport.isSupported(rawClass));
-			}
-		}
-		String subtype = typeName.substring(genInd + 1, typeName.lastIndexOf('>'));
-		if (structs.containsKey(subtype) || supportedTypes.contains(subtype)) {
-			found.put(subtype, true);
-			return found;
-		}
-		Set<String> parts = new LinkedHashSet<String>();
-		extractTypes(subtype, parts);
-		for (String st : parts) {
-			if (structs.containsKey(st) || supportedTypes.contains(st)) {
-				found.put(st, true);
-			} else {
-				TypeElement el = elements.getTypeElement(st);
-				if (el == null || !el.getTypeParameters().isEmpty()) {
-					found.put(st, containerSupport.isSupported(st));
-				} else if (isJsonObject(el)) {
-					found.put(st, true);
+	private enum PartKind {
+		UNKNOWN, TYPE_VARIABLE, OTHER
+	}
+
+	private Map<String, PartKind> analyzeParts(TypeMirror target) {
+		Map<String, PartKind> parts = new HashMap<String, PartKind>();
+		analyzePartsRecursively(target, parts);
+		return parts;
+	}
+
+	private void analyzePartsRecursively(TypeMirror target, Map<String, PartKind> parts) {
+		switch (target.getKind()) {
+			case ARRAY:
+				ArrayType at = (ArrayType) target;
+				analyzePartsRecursively(at.getComponentType(), parts);
+				break;
+
+			case DECLARED:
+				DeclaredType declaredType = (DeclaredType) target;
+				List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
+				if (typeArguments.isEmpty()) {
+					String typeName = target.toString();
+					if (structs.containsKey(typeName) || supportedTypes.contains(typeName)) {
+						parts.put(typeName, PartKind.OTHER);
+					} else {
+						parts.put(typeName, PartKind.UNKNOWN);
+					}
 				} else {
-					found.putAll(analyzeParts(el.asType()));
+					String typeName = declaredType.asElement().toString();
+					if (structs.containsKey(typeName) || supportedTypes.contains(typeName)
+							||containerSupport.isSupported(typeName)) {
+						parts.put(typeName, PartKind.OTHER);
+					} else {
+						parts.put(typeName, PartKind.UNKNOWN);
+					}
+
+					for (TypeMirror typeArgument : typeArguments) {
+						analyzePartsRecursively(typeArgument, parts);
+					}
 				}
-			}
+				break;
+
+			case TYPEVAR:
+				parts.put(target.toString(), PartKind.TYPE_VARIABLE);
+				break;
+
+			default:
+				parts.put(target.toString(), PartKind.UNKNOWN);
+				break;
 		}
-		return found;
 	}
 
 	private void extractTypes(String signature, Set<String> parts) {

--- a/library/src/main/java/com/dslplatform/json/processor/Analysis.java
+++ b/library/src/main/java/com/dslplatform/json/processor/Analysis.java
@@ -976,6 +976,12 @@ public class Analysis {
 	}
 
 	private void analyzePartsRecursively(TypeMirror target, Map<String, PartKind> parts) {
+		String typeName = target.toString();
+		if (structs.containsKey(typeName) || supportedTypes.contains(typeName)) {
+			parts.put(typeName, PartKind.OTHER);
+			return;
+		}
+
 		switch (target.getKind()) {
 			case ARRAY:
 				ArrayType at = (ArrayType) target;
@@ -986,19 +992,14 @@ public class Analysis {
 				DeclaredType declaredType = (DeclaredType) target;
 				List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
 				if (typeArguments.isEmpty()) {
-					String typeName = target.toString();
-					if (structs.containsKey(typeName) || supportedTypes.contains(typeName)) {
-						parts.put(typeName, PartKind.OTHER);
-					} else {
-						parts.put(typeName, PartKind.UNKNOWN);
-					}
+					parts.put(typeName, PartKind.UNKNOWN);
 				} else {
-					String typeName = declaredType.asElement().toString();
-					if (structs.containsKey(typeName) || supportedTypes.contains(typeName)
-							||containerSupport.isSupported(typeName)) {
-						parts.put(typeName, PartKind.OTHER);
+					String rawTypeName = declaredType.asElement().toString();
+					if (structs.containsKey(rawTypeName) || supportedTypes.contains(rawTypeName)
+							||containerSupport.isSupported(rawTypeName)) {
+						parts.put(rawTypeName, PartKind.OTHER);
 					} else {
-						parts.put(typeName, PartKind.UNKNOWN);
+						parts.put(rawTypeName, PartKind.UNKNOWN);
 					}
 
 					for (TypeMirror typeArgument : typeArguments) {
@@ -1008,11 +1009,11 @@ public class Analysis {
 				break;
 
 			case TYPEVAR:
-				parts.put(target.toString(), PartKind.TYPE_VARIABLE);
+				parts.put(typeName, PartKind.TYPE_VARIABLE);
 				break;
 
 			default:
-				parts.put(target.toString(), PartKind.UNKNOWN);
+				parts.put(typeName, PartKind.UNKNOWN);
 				break;
 		}
 	}

--- a/library/src/main/java/com/dslplatform/json/processor/AttributeInfo.java
+++ b/library/src/main/java/com/dslplatform/json/processor/AttributeInfo.java
@@ -33,6 +33,9 @@ public class AttributeInfo {
 	public final String typeName;
 	public final boolean isArray;
 	public final boolean isList;
+	public final boolean isGeneric;
+	public final Map<String, Integer> typeVariablesIndex;
+	public final boolean containsStructOwnerType;
 
 	public AttributeInfo(
 			String name,
@@ -48,7 +51,9 @@ public class AttributeInfo {
 			boolean fullMatch,
 			@Nullable CompiledJson.TypeSignature typeSignature,
 			@Nullable ConverterInfo converter,
-			boolean isJsonObject) {
+			boolean isJsonObject,
+			Map<String, Integer> typeVariablesIndex,
+			boolean containsStructOwnerType) {
 		this.id = alias != null ? alias : name;
 		this.name = name;
 		this.readMethod = readMethod;
@@ -69,6 +74,9 @@ public class AttributeInfo {
 		this.readProperty = field != null ? field.getSimpleName().toString() : readMethod.getSimpleName() + "()";
 		this.isArray = type.getKind() == TypeKind.ARRAY;
 		this.isList = typeName.startsWith("java.util.List<") || typeName.startsWith("java.util.ArrayList<");
+		this.typeVariablesIndex = typeVariablesIndex;
+		this.isGeneric = !typeVariablesIndex.isEmpty();
+		this.containsStructOwnerType = containsStructOwnerType;
 	}
 
 	public boolean isEnum(Map<String, StructInfo> structs) {

--- a/tests-java8/pom.xml
+++ b/tests-java8/pom.xml
@@ -26,6 +26,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.10.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 			<version>2.6.3</version>

--- a/tests-java8/src/test/java/com/dslplatform/json/GenericTest.java
+++ b/tests-java8/src/test/java/com/dslplatform/json/GenericTest.java
@@ -1,0 +1,89 @@
+package com.dslplatform.json;
+
+import com.dslplatform.json.runtime.TypeDefinition;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericTest {
+
+	private final DslJson<Object> dslJson = new DslJson<>(
+			new DslJson.Settings<>().allowArrayFormat(true).includeServiceLoader());
+
+	@CompiledJson
+	static class GenericModel<T, V> {
+		public T value1;
+		public V[] value2;
+		public Entry<T, V>[] value3;
+		public GenericModel<Entry<T, Integer>, V> nested;
+	}
+
+	@CompiledJson(formats = {CompiledJson.Format.ARRAY, CompiledJson.Format.OBJECT})
+	static class Entry<K, V> {
+		@JsonAttribute(index = 0)
+		public K key;
+		@JsonAttribute(index = 1)
+		public V value;
+	}
+
+	@Test
+	public void testSerializeAndDeserializeGeneric() throws IOException {
+		GenericModel<String, Double> model = generateModel();
+		Type type = new TypeDefinition<GenericModel<String, Double>>() {}.type;
+
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		JsonWriter writer = dslJson.newWriter();
+		writer.reset(os);
+
+		dslJson.serialize(writer, type, model);
+		writer.flush();
+
+		GenericModel<String, Double> result = (GenericModel<String, Double>) dslJson.deserialize(type, os.toByteArray(), os.size());
+
+		assertThat(result).isEqualToComparingFieldByFieldRecursively(model);
+	}
+
+	@Test
+	public void testBindGeneric() throws IOException {
+		GenericModel<String, Double> model = generateModel();
+		Type type = new TypeDefinition<GenericModel<String, Double>>() {}.type;
+
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		JsonWriter writer = dslJson.newWriter();
+		writer.reset(os);
+
+		dslJson.serialize(writer, type, model);
+		writer.flush();
+
+		JsonReader.BindObject<GenericModel<String, Double>> bindObject = (JsonReader.BindObject<GenericModel<String, Double>>) dslJson.tryFindBinder(type);
+		GenericModel<String, Double> result = new GenericModel<>();
+		JsonReader<Object> reader = dslJson.newReader(os.toByteArray(), os.size());
+		reader.getNextToken();
+		bindObject.bind(reader, result);
+
+		assertThat(result).isEqualToComparingFieldByFieldRecursively(model);
+	}
+
+	private GenericModel<String, Double> generateModel() {
+		GenericModel<String, Double> model = new GenericModel<>();
+		model.value1 = "a";
+		model.value2 = new Double[]{1.0, 1.1};
+		model.value3 = new Entry[]{createEntry("a", 0.1)};
+		GenericModel<Entry<String, Integer>, Double> nestedModel = new GenericModel<>();
+		nestedModel.value1 = createEntry("b", 2);
+		nestedModel.value2 = new Double[]{2.0, 2.1};
+		model.nested = nestedModel;
+		return model;
+	}
+
+	private <K, V> Entry<K, V> createEntry(K key, V value) {
+		Entry<K, V> entry = new Entry<>();
+		entry.key = key;
+		entry.value = value;
+		return entry;
+	}
+}


### PR DESCRIPTION
This PR fixes #72

Now Java8 annotation processor can create converters for generic types, e.g:
```
class Entry<K, V> {
    K key;
    V value;
}
```

Important to note that for serialization such types user must use [DslJson generic serialize API](https://github.com/ngs-doo/dsl-json/blob/master/library/src/main/java/com/dslplatform/json/DslJson.java#L2625)

Also this PR did not implement support for generic Mixins.
