### PR TITLE
EnumTemplate fails because of missing brackets

### DIFF
--- a/java8/src/main/java/com/dslplatform/json/processor/EnumTemplate.java
+++ b/java8/src/main/java/com/dslplatform/json/processor/EnumTemplate.java
@@ -44,7 +44,7 @@ class EnumTemplate {
 				code.append(writerName).append(".write(writer, ").append(external ? readValue : value).append(");\n");
 			}
 		} else if (isAllSimple(target)) {
-			code.append("writer.writeByte((byte)'\"'); writer.writeAscii(").append(readValue).append(".name()); writer.writeByte((byte)'\"');\n");
+			code.append("{writer.writeByte((byte)'\"'); writer.writeAscii(").append(readValue).append(".name()); writer.writeByte((byte)'\"');}\n");
 		} else {
 			code.append("writer.writeString(value.name());\n");
 		}


### PR DESCRIPTION
Hi,

I encountered problems generating code with the Java8 Processor for enums. The code that's beeing generated misses brackets to work properly.

For example:
```
if (instance.getSsmStage() == null) writer.writeNull();
else writer.writeByte((byte)'"'); writer.writeAscii(instance.getSsmStage().name()); writer.writeByte((byte)'"');
```

which causes a NullPointerException if the SsmStage is null.

This fix adds the brackets ;-)
Thanks,
Kristian
