### PR TITLE
Don't allocate memory when ensuring capacity

### DIFF
--- a/library/src/main/java/com/dslplatform/json/JsonWriter.java
+++ b/library/src/main/java/com/dslplatform/json/JsonWriter.java
@@ -30,7 +30,7 @@ public final class JsonWriter {
 
 	final byte[] ensureCapacity(final int free) {
 		if (position + free >= buffer.length) {
-			buffer = Arrays.copyOf(buffer, buffer.length + (buffer.length << 1) + free);
+			enlargeOrFlush(position, free);
 		}
 		return buffer;
 	}


### PR DESCRIPTION
If you are having bad luck and the buffer is full while serializing a number, the buffer size doubles - even when the JsonWriter is underlying a target OutputStream. This has the potential to grow the buffer size indefinitely, leading to OOMEs.

See also this JMC screenshot from a flight recording which shows a huge allocation when calling `NumberConverter#serialize(int, JsonWriter)` ->
`JsonWriter#ensureCapacity`. I hope this can be fixed soon :)

![screen shot 2018-11-17 at 09 56 19](https://user-images.githubusercontent.com/2163464/48659288-1165cb80-ea4f-11e8-8302-138a909be250.png)

I didn't get the tests to run so I couldn't test the change.