### PR TITLE
Fix a bug where output would be malformed when writing Null

### DIFF
--- a/library/src/main/java/com/dslplatform/json/JsonWriter.java
+++ b/library/src/main/java/com/dslplatform/json/JsonWriter.java
@@ -123,16 +123,16 @@ public final class JsonWriter {
 	 * Optimized method for writing 'null' into the JSON.
 	 */
 	public final void writeNull() {
-		final int s = position;
-		position += 4;
-		if (position >= buffer.length) {
-			enlargeOrFlush(position - 4, 0);
+		if ((position + 4)>= buffer.length) {
+			enlargeOrFlush(position, 0);
 		}
+		final int s = position;
 		final byte[] _result = buffer;
 		_result[s] = 'n';
 		_result[s + 1] = 'u';
 		_result[s + 2] = 'l';
 		_result[s + 3] = 'l';
+		position += 4;
 	}
 
 	/**

--- a/library/src/test/java/com/dslplatform/json/VariousTest.java
+++ b/library/src/test/java/com/dslplatform/json/VariousTest.java
@@ -3,9 +3,13 @@ package com.dslplatform.json;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class VariousTest {
@@ -57,5 +61,28 @@ public class VariousTest {
 		} catch (IOException e) {
 			Assert.assertTrue(e.getMessage().contains("Unable to parse input at position: 11"));
 		}
+	}
+
+	@Test
+	public void testNullSerializationWithASmallBuffer() throws IOException {
+		Map<String, Object> map = new HashMap<String, Object>();
+		List<String> list = new ArrayList<String>();
+		list.add(null);
+		list.add(null);
+		map.put("n", list);
+		DslJson<Object> dsl = new DslJson<Object>();
+		// Allocate a buffer that is small enough that it will need to
+		// be flushed when writing the first null
+		JsonWriter writer = dsl.newWriter(10);
+
+		// Create a ByteArrayOutputStream to capture the output
+		// (and so that the buffer in the writer is flushed, and not just expanded)
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		writer.reset(outputStream);
+
+		dsl.serializeMap(map, writer);
+		writer.flush();
+
+		Assert.assertEquals("{\"n\":[null,null]}", new String(outputStream.toByteArray()));
 	}
 }


### PR DESCRIPTION
When writing a null, the JsonWriter saved the start position of the write before checking if the buffer needed to be flushed. If the buffer was flushed, the old position was still used (rather than updating it to be the start of the buffer), causing the null to be written at the wrong location in the array (and then lost).