### PR TITLE
Add JsonWriter.writeRaw call

### DIFF
--- a/library/src/main/java/com/dslplatform/json/JsonWriter.java
+++ b/library/src/main/java/com/dslplatform/json/JsonWriter.java
@@ -445,6 +445,22 @@ public final class JsonWriter {
 	}
 
 	/**
+	 * Copy part of byte buffer into JSON as is.
+	 * Provided buffer can't be null.
+	 *
+	 * @param buf byte buffer to copy
+	 * @param offset in buffer to start from
+	 * @param len part of buffer to copy
+	 */
+	public final void writeRaw(final byte[] buf, final int offset, final int len) {
+		if (position + len >= buffer.length) {
+			enlargeOrFlush(position, len);
+		}
+		System.arraycopy(buf, offset, buffer, position, len);
+		position += len;
+	}
+
+	/**
 	 * Encode bytes as Base 64.
 	 * Provided value can't be null.
 	 *


### PR DESCRIPTION
This is a call with custom offset to eliminate extra mem copy, which otherwise
is required if external buffer holds data at the non zero offset.