### PR TITLE
Add @Generated annotation to generated code

### DIFF
--- a/java8/src/main/java/com/dslplatform/json/processor/CompiledJsonAnnotationProcessor.java
+++ b/java8/src/main/java/com/dslplatform/json/processor/CompiledJsonAnnotationProcessor.java
@@ -393,6 +393,8 @@ public class CompiledJsonAnnotationProcessor extends AbstractProcessor {
 			final String generatePackage = generateFullClassName.substring(0, dotIndex);
 			code.append("package ").append(generatePackage).append(";\n\n");
 		}
+		code.append("import javax.annotation.Generated;\n\n");
+		code.append("@Generated(\"dsl_json\")\n");
 		code.append("public class ").append(generateClassName).append(" implements com.dslplatform.json.Configuration {\n");
 		code.append("\tprivate static final java.nio.charset.Charset utf8 = java.nio.charset.Charset.forName(\"UTF-8\");\n");
 		code.append("\t@Override\n");


### PR DESCRIPTION
This is a really trivial change but makes a big difference in helping dsl-json play nicely with other tools

The @Generated annotation is used by many 3rd party tools to flag code that should be handled differently. In particular, it is a relatively standardised way to signal that code should be excluded from automated analysis.

One example is the NullAway annotation processor. This checks for potential nullability errors, but this is unnecessary in the generated dsl-json code.