### PR TITLE
Enabling filtering capabilities

### DIFF
--- a/library/src/main/java/com/dslplatform/json/CompiledJson.java
+++ b/library/src/main/java/com/dslplatform/json/CompiledJson.java
@@ -189,8 +189,8 @@ public @interface CompiledJson {
 
 	/**
 	 * Object attributes can be filtered out during serialization.<br>
-	 * Attributes to be filtered out can be carried by the object himself in an attribute (of Collection type)<br>
-	 * @return name of the attribute that may contain other attribute names to be filtered out from serialization
+	 * Attributes to serialize can be listed in an attribute (of Collection type) of the object to serialize<br>
+	 * @return name of the attribute that may contain other attribute names to be serialized
 	 */
 	String filteringAttribute() default "";
 }

--- a/library/src/main/java/com/dslplatform/json/CompiledJson.java
+++ b/library/src/main/java/com/dslplatform/json/CompiledJson.java
@@ -186,4 +186,11 @@ public @interface CompiledJson {
 	 * @return deserialization hint or additional serialization info
 	 */
 	String name() default "";
+
+	/**
+	 * Object attributes can be filtered out during serialization.<br>
+	 * Attributes to be filtered out can be carried by the object himself in an attribute (of Collection type)<br>
+	 * @return name of the attribute that may contain other attribute names to be filtered out from serialization
+	 */
+	String filteringAttribute() default "";
 }

--- a/library/src/main/java/com/dslplatform/json/processor/Analysis.java
+++ b/library/src/main/java/com/dslplatform/json/processor/Analysis.java
@@ -1368,11 +1368,13 @@ public class Analysis {
 			CompiledJson.Behavior onUnknown = CompiledJson.Behavior.DEFAULT;
 			CompiledJson.TypeSignature typeSignature = CompiledJson.TypeSignature.DEFAULT;
 			TypeElement deserializeAs = null;
+			String filteringAttribute = "";
 			if (!isJsonObject) {
 				if (annotation != null) {
 					onUnknown = onUnknownValue(annotation);
 					typeSignature = typeSignatureValue(annotation);
 					deserializeAs = deserializeAs(annotation);
+					filteringAttribute = filteringAttribute(annotation);
 					if (deserializeAs != null) {
 						String error = validateDeserializeAs(element, deserializeAs);
 						if (error != null) {
@@ -1453,6 +1455,7 @@ public class Analysis {
 							objectFormatPolicy,
 							deserializeAs,
 							classDiscriminator(annotation),
+							filteringAttribute,
 							className(annotation),
 							type == ObjectType.ENUM ? findEnumConstantNameSource(element) : null,
 							namingStrategy(element, annotation),
@@ -2546,6 +2549,17 @@ public class Analysis {
 			}
 		}
 		return null;
+	}
+	
+	@Nullable
+	private static String filteringAttribute(AnnotationMirror annotation) {
+		Map<? extends ExecutableElement, ? extends AnnotationValue> values = annotation.getElementValues();
+		for (ExecutableElement ee : values.keySet()) {
+			if (ee.toString().equals("filteringAttribute()")) {
+				return (String) values.get(ee).getValue();
+			}
+		}
+		return "";
 	}
 
 	private static final Map<String, NamingStrategy> namingCache = new HashMap<String, NamingStrategy>();

--- a/library/src/main/java/com/dslplatform/json/processor/ConverterTemplate.java
+++ b/library/src/main/java/com/dslplatform/json/processor/ConverterTemplate.java
@@ -717,7 +717,8 @@ class ConverterTemplate {
 					}
 				}
 				if (checkFiltering) {
-					code.append(" && (").append("instance.").append(si.filteringAttribute).append("().size()==0 || ").append("instance.").append(si.filteringAttribute).append("().contains(\"").append(attr.name).append("\"))");
+					if (checkDefaults) code.append(" && ");
+					code.append("(").append("instance.").append(si.filteringAttribute).append("().size()==0 || ").append("instance.").append(si.filteringAttribute).append("().contains(\"").append(attr.name).append("\"))");
 				}
 				code.append(") {\n");
 			}

--- a/library/src/main/java/com/dslplatform/json/processor/ConverterTemplate.java
+++ b/library/src/main/java/com/dslplatform/json/processor/ConverterTemplate.java
@@ -689,6 +689,7 @@ class ConverterTemplate {
 		code.append("\t\tpublic boolean writeContentMinimal(final com.dslplatform.json.JsonWriter writer, final ");
 		code.append(className).append(" instance) {\n");
 		code.append("\t\t\tboolean hasWritten = false;\n");
+		boolean checkFiltering = !si.filteringAttribute.isEmpty();
 		for (AttributeInfo attr : sortedAttributes) {
 			if (!attr.canWriteOutput()) continue;
 			String defaultValue = context.getDefault(attr);
@@ -697,21 +698,26 @@ class ConverterTemplate {
 			boolean isPrimitive = !attr.typeName.equals(Analysis.objectName(attr.typeName));
 			String readValue = "instance." + attr.readProperty;
 
-			if (checkDefaults) {
+			if (checkDefaults || checkFiltering) {
 				code.append("\t\t\tif (");
-				if ("null".equals(defaultValue) || isPrimitive) {
-					code.append(readValue).append(" != ").append(defaultValue);
-				} else if (attr.notNull && attr.isArray) {
-					code.append(readValue).append(" != null && ").append(readValue).append(".length != 0");
-				} else if (attr.notNull && (attr.isList || attr.isSet || attr.isMap)) {
-					code.append(readValue).append(" != null && !").append(readValue).append(".isEmpty()");
-				} else {
-					StructInfo target = context.structs.get(attr.typeName);
-					if (target != null && (target.hasEmptyCtor() || target.hasKnownConversion() || target.annotatedFactory != null)) {
-						code.append(readValue).append(" != null");
+				if (checkDefaults) {
+					if ("null".equals(defaultValue) || isPrimitive) {
+						code.append(readValue).append(" != ").append(defaultValue);
+					} else if (attr.notNull && attr.isArray) {
+						code.append(readValue).append(" != null && ").append(readValue).append(".length != 0");
+					} else if (attr.notNull && (attr.isList || attr.isSet || attr.isMap)) {
+						code.append(readValue).append(" != null && !").append(readValue).append(".isEmpty()");
 					} else {
-						code.append(readValue).append(" != null && !").append(defaultValue).append(".equals(").append(readValue).append(")");
+						StructInfo target = context.structs.get(attr.typeName);
+						if (target != null && (target.hasEmptyCtor() || target.hasKnownConversion() || target.annotatedFactory != null)) {
+							code.append(readValue).append(" != null");
+						} else {
+							code.append(readValue).append(" != null && !").append(defaultValue).append(".equals(").append(readValue).append(")");
+						}
 					}
+				}
+				if (checkFiltering) {
+					code.append(" && (").append("instance.").append(si.filteringAttribute).append("().size()==0 || ").append("instance.").append(si.filteringAttribute).append("().contains(\"").append(attr.name).append("\"))");
 				}
 				code.append(") {\n");
 			}

--- a/library/src/main/java/com/dslplatform/json/processor/StructInfo.java
+++ b/library/src/main/java/com/dslplatform/json/processor/StructInfo.java
@@ -29,6 +29,7 @@ public class StructInfo {
 	public final CompiledJson.ObjectFormatPolicy objectFormatPolicy;
 	public final TypeElement deserializeAs;
 	public final String discriminator;
+	public final String filteringAttribute;
 	public final String deserializeName;
 	public final @Nullable NamingStrategy namingStrategy;
 	public final EnumSet<CompiledJson.Format> formats;
@@ -65,6 +66,7 @@ public class StructInfo {
 			CompiledJson.ObjectFormatPolicy objectFormatPolicy,
 			@Nullable TypeElement deserializeAs,
 			@Nullable String discriminator,
+			@Nullable String filteringAttribute,
 			@Nullable String deserializeName,
 			@Nullable Element enumConstantNameSource,
 			@Nullable NamingStrategy namingStrategy,
@@ -86,6 +88,7 @@ public class StructInfo {
 		this.objectFormatPolicy = objectFormatPolicy;
 		this.deserializeAs = deserializeAs;
 		this.discriminator = discriminator != null ? discriminator : "";
+		this.filteringAttribute = filteringAttribute != null ? filteringAttribute : "";
 		this.deserializeName = deserializeName != null ? deserializeName : "";
 		this.enumConstantNameSource = enumConstantNameSource;
 		this.namingStrategy = namingStrategy;
@@ -134,6 +137,7 @@ public class StructInfo {
 		this.objectFormatPolicy = CompiledJson.ObjectFormatPolicy.DEFAULT;
 		this.deserializeAs = null;
 		this.discriminator = "";
+		this.filteringAttribute = "";
 		this.deserializeName = "";
 		this.enumConstantNameSource = null;
 		this.namingStrategy = null;


### PR DESCRIPTION
Proposal for enabling field filtering capabilities in serialization.

Functional description:
 - new attribute _filteringAttribute_ in _@CompiledJson_ annotation to reference an attribute of the current object that may contain attribute names to serialize (the filteringAttribute must be a _Collection_)
 - if _filteringAttribute_ is set, then the generated converter add a check on it to only serialize fields listed in the collection