### PR TITLE
Allow run time fine Crain control of. the properties that are output

### DIFF
--- a/library/src/main/java/com/dslplatform/json/CompiledJson.java
+++ b/library/src/main/java/com/dslplatform/json/CompiledJson.java
@@ -83,7 +83,11 @@ public @interface CompiledJson {
 		 * Serialize only properties marked with annotations.
 		 * It will respect the omitDefault setting and serialize them accordingly.
 		 */
-		EXPLICIT
+		EXPLICIT,
+		/**
+		 * Serialize properties as determined by the JsonWriter at run time.
+		 */
+		CONTROLLED
 	}
 
 	Class namingStrategy() default NamingStrategy.class;

--- a/library/src/main/java/com/dslplatform/json/PropertyAccessor.java
+++ b/library/src/main/java/com/dslplatform/json/PropertyAccessor.java
@@ -1,0 +1,5 @@
+package com.dslplatform.json;
+
+public interface PropertyAccessor<T> {
+    Object getField(T instance, PropertyInfo<T> field);
+}

--- a/library/src/main/java/com/dslplatform/json/PropertyInfo.java
+++ b/library/src/main/java/com/dslplatform/json/PropertyInfo.java
@@ -1,0 +1,17 @@
+package com.dslplatform.json;
+
+public final class PropertyInfo<T> {
+    private final String name;
+    private final byte[] quoted;
+    public PropertyInfo(String name, byte[] quoted) {
+        this.name = name;
+        this.quoted = quoted;
+    }
+    public void writeQuoted(com.dslplatform.json.JsonWriter writer) {
+        writer.writeAscii(quoted);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/library/src/main/java/com/dslplatform/json/UnknownSerializer.java
+++ b/library/src/main/java/com/dslplatform/json/UnknownSerializer.java
@@ -2,6 +2,6 @@ package com.dslplatform.json;
 
 import java.io.IOException;
 
-interface UnknownSerializer {
+public interface UnknownSerializer {
 	void serialize(JsonWriter writer, @Nullable Object unknown) throws IOException;
 }

--- a/tests-java8/src/test/java/com/dslplatform/json/TestJsonWriters.java
+++ b/tests-java8/src/test/java/com/dslplatform/json/TestJsonWriters.java
@@ -1,0 +1,176 @@
+package com.dslplatform.json;
+
+import org.junit.Assert;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class TestJsonWriters {
+    static abstract class TestJsonWriter extends JsonWriter {
+        TestJsonWriter(UnknownSerializer unknownSerializer) {
+            super(unknownSerializer);
+        }
+
+        TestJsonWriter(int size, UnknownSerializer unknownSerializer) {
+            super(size, unknownSerializer);
+        }
+
+        TestJsonWriter(byte[] buffer, UnknownSerializer unknownSerializer) {
+            super(buffer, unknownSerializer);
+        }
+
+        protected final void recordError(Object value) {
+            throw new Error("Unexpected call: " + value);
+        }
+        //This could typically be a record, but it's not supported in Java 8
+        static class FilterInfoImpl implements FilterInfo {
+            final Object instance;
+            final Class<?> clazz;
+
+            FilterInfoImpl(@Nullable Object instance, Class<?> clazz) {
+                this.instance = instance;
+                this.clazz = clazz;
+            }
+        }
+        private final IdentityHashMap<Object, FilterInfoImpl> filterInfoMap = new IdentityHashMap<>();
+        private final IdentityHashMap<FilterInfoImpl, Object> filterInfoReverseMap = new IdentityHashMap<>();
+
+        protected final void validateCommonParams(@Nullable Object instance, Class<?> clazz, FilterInfo _filterInfo) {
+            assertNotNull(_filterInfo);
+            assertTrue(_filterInfo instanceof FilterInfoImpl);
+            final FilterInfoImpl filterInfo = (FilterInfoImpl) _filterInfo;
+            if (instance != null) {
+                assertSame(filterInfo, filterInfoMap.get(instance));
+            }
+            assertSame(filterInfo.instance, instance);
+            assertSame(filterInfo.clazz, clazz);
+        }
+
+        @Override
+        public <C> FilterInfo controlledFilterInfo(@Nullable C instance, Class<C> clazz, PropertyAccessor<C> access, List<PropertyInfo<C>> fields) {
+            FilterInfoImpl result = new FilterInfoImpl(instance, clazz);
+            if (instance != null) {
+                filterInfoMap.put(instance, result);
+            }
+            filterInfoReverseMap.put(result, instance);
+            return result;
+        }
+
+    }
+    static class AllWriterFactory extends  JsonWriter.Factory {
+        static class WriterImpl extends TestJsonWriter {
+            WriterImpl(UnknownSerializer unknownSerializer) {
+                super(unknownSerializer);
+            }
+
+            WriterImpl(int size, UnknownSerializer unknownSerializer) {
+                super(size, unknownSerializer);
+            }
+
+            WriterImpl(byte[] buffer, UnknownSerializer unknownSerializer) {
+                super(buffer, unknownSerializer);
+            }
+        }
+        @Override
+        public JsonWriter create(UnknownSerializer unknownSerializer) {
+            return new WriterImpl(unknownSerializer);
+        }
+
+        @Override
+        public JsonWriter create(int size, UnknownSerializer unknownSerializer) {
+            return new WriterImpl(size, unknownSerializer);
+        }
+
+        @Override
+        public JsonWriter create(byte[] buffer, UnknownSerializer unknownSerializer) {
+            return new WriterImpl(buffer, unknownSerializer);
+        }
+    }
+    static class NoneWriterFactory extends  JsonWriter.Factory {
+        static class WriterImpl extends TestJsonWriter {
+            WriterImpl(UnknownSerializer unknownSerializer) {
+                super(unknownSerializer);
+            }
+
+            WriterImpl(int size, UnknownSerializer unknownSerializer) {
+                super(size, unknownSerializer);
+            }
+
+            WriterImpl(byte[] buffer, UnknownSerializer unknownSerializer) {
+                super(buffer, unknownSerializer);
+            }
+
+            @Override
+            public <C> List<PropertyInfo<C>> controlledStart(C instance, Class<C> clazz, PropertyAccessor<C> access, List<PropertyInfo<C>> properties, FilterInfo filterInfo) {
+                return Collections.emptyList();
+            }
+        }
+        @Override
+        public JsonWriter create(UnknownSerializer unknownSerializer) {
+            return new WriterImpl(unknownSerializer);
+        }
+
+        @Override
+        public JsonWriter create(int size, UnknownSerializer unknownSerializer) {
+            return new WriterImpl(size, unknownSerializer);
+        }
+
+        @Override
+        public JsonWriter create(byte[] buffer, UnknownSerializer unknownSerializer) {
+            return new WriterImpl(buffer, unknownSerializer);
+        }
+    }
+    static class SecretWriterFactory extends  JsonWriter.Factory {
+        final String fieldName;
+
+        public SecretWriterFactory(String fieldName) {
+            super();
+            this.fieldName = Objects.requireNonNull(fieldName);
+        }
+
+        static class WriterImpl extends TestJsonWriter {
+            private final SecretWriterFactory parent;
+
+            WriterImpl(SecretWriterFactory parent, UnknownSerializer unknownSerializer) {
+                super(unknownSerializer);
+                this.parent = parent;
+            }
+
+            WriterImpl(SecretWriterFactory parent, int size, UnknownSerializer unknownSerializer) {
+                super(size, unknownSerializer);
+                this.parent = parent;
+            }
+
+            WriterImpl(SecretWriterFactory parent, byte[] buffer, UnknownSerializer unknownSerializer) {
+                super(buffer, unknownSerializer);
+                this.parent = parent;
+            }
+
+            @Override
+            public <C> JsonWriter controlledPrepareForProperty(C instance, Class<C> clazz, PropertyAccessor<C> access, FilterInfo filterInfo, PropertyInfo<C> property, JsonWriter writer) {
+                super.controlledPrepareForProperty(instance, clazz, access, filterInfo, property, writer);
+                if (parent.fieldName.equals(property.getName())) {
+                    writeString("That's a secret!");
+                    return null;
+                }
+                return this;
+            }
+        }
+        @Override
+        public JsonWriter create(UnknownSerializer unknownSerializer) {
+            return new WriterImpl(this, unknownSerializer);
+        }
+
+        @Override
+        public JsonWriter create(int size, UnknownSerializer unknownSerializer) {
+            return new WriterImpl(this, size, unknownSerializer);
+        }
+
+        @Override
+        public JsonWriter create(byte[] buffer, UnknownSerializer unknownSerializer) {
+            return new WriterImpl(this, buffer, unknownSerializer);
+        }
+    }
+
+}


### PR DESCRIPTION
allow the json writer to have fine control of the properties that are written

this allows
1. filtering of the properties
2. re-ordering of the properties
3. changes to the names or values of the properties (e.g. for removal of secrets)