### PR TITLE
Quoted double parsing

### DIFF
--- a/library/src/main/java/com/dslplatform/json/NumberConverter.java
+++ b/library/src/main/java/com/dslplatform/json/NumberConverter.java
@@ -382,7 +382,7 @@ public abstract class NumberConverter {
 		return new NumberInfo(result, len);
 	}
 
-	public static double deserializeDouble(final JsonReader reader) throws IOException {
+	public static double deserializeDouble0(final JsonReader reader) throws IOException {
 		if (reader.last() == '"') {
 			final int position = reader.getCurrentIndex();
 			final char[] buf = reader.readSimpleQuote();
@@ -393,30 +393,54 @@ public abstract class NumberConverter {
 		final byte[] buf = reader.buffer;
 		final byte ch = buf[start];
 		if (ch == '-') {
-			return -parseDouble(buf, reader, start, end, 1);
+			return -parseDouble(buf, reader, start, end, 1, false);
 		}
-		return parseDouble(buf, reader, start, end, 0);
+		return parseDouble(buf, reader, start, end, 0, false);
 	}
 
-	private static double parseDouble(final byte[] buf, final JsonReader reader, final int start, final int end, final int offset) throws IOException {
+	public static double deserializeDouble(final JsonReader reader) throws IOException {
+		final boolean withQuotes = reader.last() == '"';
+		final int start, end;
+		if (withQuotes) {
+			final char[] tmp = reader.readSimpleQuote();
+			start = reader.getTokenStart();
+			end = reader.getCurrentIndex() - 1;
+		}
+		else {
+			start = reader.scanNumber();
+			end = reader.getCurrentIndex();
+		}
+		final byte[] buf = reader.buffer;
+		final byte ch = buf[start];
+		if (ch == '-') {
+			return -parseDouble(buf, reader, start, end, 1, withQuotes);
+		}
+		return parseDouble(buf, reader, start, end, 0, withQuotes);
+	}
+
+	private static double parseDouble(final byte[] buf, final JsonReader reader, final int start, final int end, final int offset, final boolean withQuotes) throws IOException {
 		if (end - start - offset > reader.doubleLengthLimit) {
 			if (end == reader.length()) {
 				final NumberInfo tmp = readLongNumber(reader, start + offset);
-				return parseDoubleGeneric(tmp.buffer, tmp.length, reader, false);
+				return parseDoubleGeneric(tmp.buffer, tmp.length, reader, withQuotes);
 			}
-			return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, false);
+			return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, withQuotes);
 		}
 		long value = 0;
 		byte ch = ' ';
 		int i = start + offset;
-		final boolean leadingZero = buf[start + offset] == 48;
+		final boolean leadingZero = buf[i] == 48;
+		// Add support for NaN and Infinity now that this method handles quoted values
+		if (buf[i] == 'N' || buf[i] == 'I') {
+			return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, withQuotes);
+		}
 		for (; i < end; i++) {
 			ch = buf[i];
 			if (ch == '.' || ch == 'e' || ch == 'E') break;
 			final int ind = buf[i] - 48;
 			if (ind < 0 || ind > 9) {
 				if (leadingZero && i > start + offset + 1) {
-					numberException(reader, start, end, "Leading zero is not allowed");
+					numberException(reader, start, end + (withQuotes ? 2 : 0), "Leading zero is not allowed");
 				}
 				if (i > start + offset && reader.allWhitespace(i, end)) return value;
 				numberException(reader, start, end, "Unknown digit", (char)ch);
@@ -424,7 +448,7 @@ public abstract class NumberConverter {
 			value = (value << 3) + (value << 1) + ind;
 		}
 		if (i == start + offset) numberException(reader, start, end, "Digit not found");
-		else if (leadingZero && ch != '.' && i > start + offset + 1) numberException(reader, start, end, "Leading zero is not allowed");
+		else if (leadingZero && ch != '.' && i > start + offset + 1) numberException(reader, start, end + (withQuotes ? 2 : 0), "Leading zero is not allowed");
 		else if (i == end) return value;
 		else if (ch == '.') {
 			i++;
@@ -438,7 +462,7 @@ public abstract class NumberConverter {
 				maxLen = i + 15;
 				ch = buf[i];
 				if (ch == '0' && end > maxLen) {
-					return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, false);
+					return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, withQuotes);
 				} else if (ch < '8') {
 					preciseDividor = 1e14;
 					expDiff = -1;
@@ -477,7 +501,7 @@ public abstract class NumberConverter {
 				return doubleExponent(reader, value, i - decPos,0, buf, start, end, offset, i);
 			}
 			if (reader.doublePrecision == JsonReader.DoublePrecision.HIGH) {
-				return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, false);
+				return parseDoubleGeneric(reader.prepareBuffer(start + offset, end - start - offset), end - start - offset, reader, withQuotes);
 			}
 			int decimals = 0;
 			final int decLimit = start + offset + 18 < end ? start + offset + 18 : end;

--- a/library/src/main/java/com/dslplatform/json/NumberConverter.java
+++ b/library/src/main/java/com/dslplatform/json/NumberConverter.java
@@ -382,22 +382,6 @@ public abstract class NumberConverter {
 		return new NumberInfo(result, len);
 	}
 
-	public static double deserializeDouble0(final JsonReader reader) throws IOException {
-		if (reader.last() == '"') {
-			final int position = reader.getCurrentIndex();
-			final char[] buf = reader.readSimpleQuote();
-			return parseDoubleGeneric(buf, reader.getCurrentIndex() - position - 1, reader, true);
-		}
-		final int start = reader.scanNumber();
-		final int end = reader.getCurrentIndex();
-		final byte[] buf = reader.buffer;
-		final byte ch = buf[start];
-		if (ch == '-') {
-			return -parseDouble(buf, reader, start, end, 1, false);
-		}
-		return parseDouble(buf, reader, start, end, 0, false);
-	}
-
 	public static double deserializeDouble(final JsonReader reader) throws IOException {
 		final boolean withQuotes = reader.last() == '"';
 		final int start, end;

--- a/library/src/test/java/com/dslplatform/json/NumberConverterTest.java
+++ b/library/src/test/java/com/dslplatform/json/NumberConverterTest.java
@@ -1563,4 +1563,20 @@ public class NumberConverterTest {
 
 		Assert.assertEquals(expected, actual);
 	}
+
+	@Test
+	public void quotedDoubles() throws IOException {
+		// setup
+		final JsonWriter sw = new JsonWriter(null);
+		final String[] inputs = { "\"104923.87000004\"", "\"0.00230002\"","\"-104923.87000004\"", "\"-0.00230002\"" };
+		final JsonReader<Object> jr = dslJson.newReader(new byte[0]);
+		for (String inp : inputs) {
+			double expected = Double.parseDouble(inp.substring(1, inp.length() - 1));
+			byte[] bytes = inp.getBytes("UTF-8");
+			jr.process(bytes, bytes.length);
+			jr.read();
+			double number = NumberConverter.deserializeDouble(jr);
+			Assert.assertEquals(expected, number, 0);
+		}
+	}
 }


### PR DESCRIPTION
Hey @zapov,

I was profiling an app of ours using your fantastic serialization library and I saw that deserializing quoted doubles was causing excessive creation of strings due to the code falling back to `Double.parseDouble` in `parseDoubleGeneric`.

Please take a look at this PR and advise if this approach looks reasonable and what else you think needs completing in order to consider merging the change.