### PR TITLE
Security Fix: Potential XXE Vulnerability in createDocument function

### DIFF
--- a/library/src/main/java/com/dslplatform/json/XmlConverter.java
+++ b/library/src/main/java/com/dslplatform/json/XmlConverter.java
@@ -90,6 +90,11 @@ public abstract class XmlConverter {
 	private static synchronized Document createDocument() {
 		try {
 			final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+			// Securely configure the DocumentBuilderFactory
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
 			final DocumentBuilder builder = factory.newDocumentBuilder();
 			return builder.newDocument();
 		} catch (ParserConfigurationException e) {


### PR DESCRIPTION
This PR addresses a potential vulnerability in the createDocument() function in XmlConverter.java that could lead to XML External Entity (XXE) attacks because it does not set the XMLConstants.ACCESS_EXTERNAL_DTD or XMLConstants.ACCESS_EXTERNAL_SCHEMA attributes to restrict access to external resources. This issue was originally reported and resolved in the repository via this commit https://github.com/soartech/jsoar/commit/ae6a2ecf1c86488504c498759d9258973cc68387.

**Fix**

- Restrict Access to External Document Type Definitions (DTDs) and Schemas

**References**
CWE-611: Improper Restriction of XML External Entity Reference
https://github.com/soartech/jsoar/commit/ae6a2ecf1c86488504c498759d9258973cc68387